### PR TITLE
Add Entity Framework and SQLite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,4 @@ FakesAssemblies/
 GeneratedArtifacts/
 _Pvt_Extensions/
 ModelManifest.xml
+*.targets

--- a/UniversalWindowsEF7SQLite/project.json
+++ b/UniversalWindowsEF7SQLite/project.json
@@ -1,5 +1,8 @@
 ﻿{
   "dependencies": {
+    "EntityFramework.Commands": "7.0.0-beta6",
+    "EntityFramework.SQLite": "7.0.0-beta6",
+    "Microsoft.CodeAnalysis.CSharp": "1.0.0",
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.0.0"
   },
   "frameworks": {


### PR DESCRIPTION
Added EntityFramework.SQLite and EntityFramework.Commands v1.0.0-beta6. Microsoft.CodeAnalysis.CSharp is added for bug work around.
PM Commands:
- dnvm use 1.0.0-beta6
- Install-Package EntityFramework.SQLite –Version 7.0.0-beta6
- Install-Package EntityFramework.Commands –Version 7.0.0-beta6
- Install-Package Microsoft.CodeAnalysis.CSharp –Version 1.0.0
